### PR TITLE
Added rootElem to hash if it has a name attribute

### DIFF
--- a/element.js
+++ b/element.js
@@ -8,9 +8,8 @@ function buildElems(rootElem) {
     var hash = {}
     if (rootElem.name) {
     	hash[rootElem.name] = rootElem
-    	return hash
     }
-    
+
     walk(rootElem, function (child) {
         if (child.name) {
             hash[child.name] = child

--- a/element.js
+++ b/element.js
@@ -6,7 +6,11 @@ module.exports = getFormData
 
 function buildElems(rootElem) {
     var hash = {}
-
+    if (rootElem.name) {
+    	hash[rootElem.name] = rootElem
+    	return hash
+    }
+    
     walk(rootElem, function (child) {
         if (child.name) {
             hash[child.name] = child

--- a/test/select.js
+++ b/test/select.js
@@ -2,6 +2,7 @@ var test = require("tape")
 var h = require("hyperscript")
 
 var FormData = require("../index")
+var getFormData = require("../element")
 
 test("FormData works with <select> elements", function (assert) {
     var elements = {
@@ -13,6 +14,23 @@ test("FormData works with <select> elements", function (assert) {
     }
 
     var data = FormData(elements)
+
+    assert.deepEqual(data, {
+        foo: "two"
+    })
+
+    assert.end()
+})
+
+test("getFormData works when root element has a name", function(assert) {
+    var element = h("select", {
+        name: "foo"
+    }, [
+        h("option", { value: "one" })
+        , h("option", { value: "two", selected: true })
+    ])
+
+    var data = getFormData(element)
 
     assert.deepEqual(data, {
         foo: "two"


### PR DESCRIPTION
This fixes part of the issue seen over at https://github.com/Raynos/mercury/issues/125 and https://github.com/Raynos/mercury/issues/48 - to me it makes sense to be able to only parse part of a form or even just a single form element. But that may be a matter for discussion...
